### PR TITLE
leJOSのサンプルプログラムの4ms周期の作り方を修正

### DIFF
--- a/SampleCode/EV3way_leJOS_sample/ev3sample/src/jp/etrobo/ev3/sample/EV3waySample.java
+++ b/SampleCode/EV3way_leJOS_sample/ev3sample/src/jp/etrobo/ev3/sample/EV3waySample.java
@@ -89,7 +89,7 @@ public class EV3waySample {
      * 走行開始時の作業スケジューリング。
      */
     public void start() {
-        futureDrive = scheduler.scheduleAtFixedRate(driveTask, 0, 4, TimeUnit.MILLISECONDS);
+        futureDrive = scheduler.schedule(driveTask, 0, TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/SampleCode/EV3way_leJOS_sample/ev3sample/src/jp/etrobo/ev3/sample/EV3wayTask.java
+++ b/SampleCode/EV3way_leJOS_sample/ev3sample/src/jp/etrobo/ev3/sample/EV3wayTask.java
@@ -5,6 +5,8 @@
  */
 package jp.etrobo.ev3.sample;
 
+import lejos.utility.Delay;
+
 /**
  * EV3way を制御するタスク。
  */
@@ -24,7 +26,14 @@ public class EV3wayTask implements Runnable {
      */
     @Override
     public void run() {
-        body.controlDrive();
-        body.controlTail(EV3way.TAIL_ANGLE_DRIVE);
+        while(true){
+            long time = System.currentTimeMillis();
+            body.controlDrive();
+            body.controlTail(EV3way.TAIL_ANGLE_DRIVE);
+            time = System.currentTimeMillis() - time;
+            if(time < 4){
+                Delay.msDelay(4 - time);
+            }
+        }
     }
 }


### PR DESCRIPTION
leJOSのサンプルプログラムのバランスパラメータの値をEV3RTと同じに修正した結果、
不安定になってしまっていたため、4ms周期の作り方を修正しました。

runメソッドの中でループするため1回しか起動しないようにする 。
EV3wayTaskのrunメソッドの中で処理時間を計測し4msになるようにループする。


